### PR TITLE
feat: 게시글 작성 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+application-secret.yml
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/cloud/ieum/Security/SecurityConfig.java
+++ b/src/main/java/cloud/ieum/Security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {  //해당 URL은 필터 거치지 않겠다
         log.info("무시하기");
-        return (web -> web.ignoring().requestMatchers("/img/**", "/css/**", "/js/**"));
+        return (web -> web.ignoring().requestMatchers("/img/**", "/css/**", "/js/**", "/content", "/h2-console/**"));
         //return (web -> web.ignoring().antMatchers("/test"));
     }
     @Bean

--- a/src/main/java/cloud/ieum/content/category/Category.java
+++ b/src/main/java/cloud/ieum/content/category/Category.java
@@ -1,0 +1,13 @@
+package cloud.ieum.content.category;
+
+import jakarta.persistence.*;
+
+@Entity(name = "category_tb")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/cloud/ieum/content/category/CategoryJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/category/CategoryJpaRepository.java
@@ -1,0 +1,6 @@
+package cloud.ieum.content.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryJpaRepository extends JpaRepository<Category, Integer> {
+}

--- a/src/main/java/cloud/ieum/content/image/Image.java
+++ b/src/main/java/cloud/ieum/content/image/Image.java
@@ -1,0 +1,23 @@
+package cloud.ieum.content.image;
+
+import cloud.ieum.content.post.Post;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "image_tb")
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    private Post post;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+}

--- a/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
@@ -1,0 +1,6 @@
+package cloud.ieum.content.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageJpaRepository extends JpaRepository<Image, Integer> {
+}

--- a/src/main/java/cloud/ieum/content/image/ImageService.java
+++ b/src/main/java/cloud/ieum/content/image/ImageService.java
@@ -1,0 +1,37 @@
+package cloud.ieum.content.image;
+
+import cloud.ieum.content.post.Post;
+import cloud.ieum.content.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ImageService {
+    private final S3Service s3Service;
+    private final ImageJpaRepository imageJpaRepository;
+
+    public List<String> upload(List<MultipartFile> images) throws IOException {
+        List<String> imgUrls = new ArrayList<>();
+        for (MultipartFile image : images) {
+            imgUrls.add(s3Service.uploadFile(image));
+        }
+        return imgUrls;
+    }
+
+    public void create(List<String> imgUrls, Post post) {
+        List<Image> imageList = new ArrayList<>();
+        for (String url : imgUrls) {
+            Image image = Image.builder()
+                    .post(post)
+                    .imageUrl(url).build();
+            imageList.add(image);
+        }
+        imageJpaRepository.saveAll(imageList);
+    }
+}

--- a/src/main/java/cloud/ieum/content/post/Post.java
+++ b/src/main/java/cloud/ieum/content/post/Post.java
@@ -1,0 +1,28 @@
+package cloud.ieum.content.post;
+
+import cloud.ieum.content.subcategory.SubCategory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity(name = "post_tb")
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private SubCategory subCategory;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+}

--- a/src/main/java/cloud/ieum/content/post/PostJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/post/PostJpaRepository.java
@@ -1,0 +1,7 @@
+package cloud.ieum.content.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostJpaRepository extends JpaRepository<Post, Integer> {
+
+}

--- a/src/main/java/cloud/ieum/content/post/PostRequestDto.java
+++ b/src/main/java/cloud/ieum/content/post/PostRequestDto.java
@@ -1,0 +1,12 @@
+package cloud.ieum.content.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PostRequestDto {
+    String title;
+    Integer subCategory;
+    String description;
+}

--- a/src/main/java/cloud/ieum/content/post/PostRestController.java
+++ b/src/main/java/cloud/ieum/content/post/PostRestController.java
@@ -1,0 +1,26 @@
+package cloud.ieum.content.post;
+
+import cloud.ieum.utils.ApiUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequestMapping("/content")
+@RequiredArgsConstructor
+@RestController
+public class PostRestController {
+    private final PostService postService;
+    @PostMapping("")
+    public ResponseEntity<?> postContent(@RequestPart("data") PostRequestDto postRequestDto,
+                                         @RequestPart(value = "file", required = false) List<MultipartFile> images) throws Exception {
+
+        postService.create(postRequestDto, images);
+        return ResponseEntity.ok().body(ApiUtils.success(null));
+    }
+}

--- a/src/main/java/cloud/ieum/content/post/PostService.java
+++ b/src/main/java/cloud/ieum/content/post/PostService.java
@@ -1,0 +1,42 @@
+package cloud.ieum.content.post;
+
+import cloud.ieum.content.image.ImageService;
+import cloud.ieum.content.subcategory.SubCategory;
+import cloud.ieum.content.subcategory.SubCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final SubCategoryService subCategoryService;
+    private final ImageService imageService;
+    private final PostJpaRepository postJpaRepository;
+    @Transactional
+    public void create(PostRequestDto postRequestDto, List<MultipartFile> images) throws Exception {
+        // subCategory 프록시 객체
+        SubCategory subCategory = subCategoryService.getReferenceById(postRequestDto.getSubCategory());
+
+        // s3 업로드 url
+        List<String> imgUrls = new ArrayList<>();
+        if (images != null && !images.isEmpty()) {
+            imgUrls = imageService.upload(images);
+        }
+        
+        Post post = Post.builder()
+                .title(postRequestDto.title)
+                .content(postRequestDto.description)
+                .subCategory(subCategory)
+                .build();
+        postJpaRepository.save(post);
+
+        if (!imgUrls.isEmpty()) {
+            imageService.create(imgUrls, post);
+        }
+    }
+}

--- a/src/main/java/cloud/ieum/content/s3/S3Config.java
+++ b/src/main/java/cloud/ieum/content/s3/S3Config.java
@@ -1,0 +1,33 @@
+package cloud.ieum.content.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/cloud/ieum/content/s3/S3Service.java
+++ b/src/main/java/cloud/ieum/content/s3/S3Service.java
@@ -1,0 +1,33 @@
+package cloud.ieum.content.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile multipartFile) throws IOException {
+        LocalDateTime now = LocalDateTime.now();
+        String timeString = now.toString().replace(':', '_');
+        String filename = timeString + '-' + multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        amazonS3.putObject(bucket, filename, multipartFile.getInputStream(), metadata);
+        return amazonS3.getUrl(bucket, filename).toString();
+    }
+}

--- a/src/main/java/cloud/ieum/content/subcategory/SubCategory.java
+++ b/src/main/java/cloud/ieum/content/subcategory/SubCategory.java
@@ -1,0 +1,17 @@
+package cloud.ieum.content.subcategory;
+
+import cloud.ieum.content.category.Category;
+import jakarta.persistence.*;
+
+@Entity(name = "subcategory_tb")
+public class SubCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/cloud/ieum/content/subcategory/SubCategoryJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/subcategory/SubCategoryJpaRepository.java
@@ -1,0 +1,6 @@
+package cloud.ieum.content.subcategory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubCategoryJpaRepository extends JpaRepository<SubCategory, Integer> {
+}

--- a/src/main/java/cloud/ieum/content/subcategory/SubCategoryService.java
+++ b/src/main/java/cloud/ieum/content/subcategory/SubCategoryService.java
@@ -1,0 +1,13 @@
+package cloud.ieum.content.subcategory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SubCategoryService {
+    private final SubCategoryJpaRepository subCategoryJpaRepository;
+    public SubCategory getReferenceById(Integer subCategoryId) {
+        return subCategoryJpaRepository.getReferenceById(subCategoryId);
+    }
+}

--- a/src/main/java/cloud/ieum/utils/ApiUtils.java
+++ b/src/main/java/cloud/ieum/utils/ApiUtils.java
@@ -1,0 +1,30 @@
+package cloud.ieum.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+public class ApiUtils {
+
+    public static <T> ApiResult<T> success(T response) {
+        return new ApiResult<>(true, response, null);
+    }
+
+    public static ApiResult<?> error(String message, HttpStatus status) {
+        return new ApiResult<>(false, null, new ApiError(message, status.value()));
+    }
+
+    @Getter @Setter @AllArgsConstructor
+    public static class ApiResult<T> {
+        private final boolean success;
+        private final T response;
+        private final ApiError error;
+    }
+
+    @Getter @Setter @AllArgsConstructor
+    public static class ApiError {
+        private final String message;
+        private final int status;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,8 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  config:
+    import: classpath:/application-secret.yml
 
 
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,13 @@
+INSERT INTO category_tb (name) VALUES ('취업/진로');
+INSERT INTO category_tb (name) VALUES ('전세/임대');
+INSERT INTO category_tb (name) VALUES ('가사/집안일');
+INSERT INTO category_tb (name) VALUES ('운동');
+INSERT INTO category_tb (name) VALUES ('게임');
+INSERT INTO category_tb (name) VALUES ('음악');
+
+INSERT INTO subcategory_tb (category_id,name) VALUES (1,'대학진학'), (1,'창업'), (1,'자격증취득'), (1,'직업훈련');
+INSERT INTO subcategory_tb (category_id,name) VALUES (2,'전세자금 대출'), (2,'정부지원정책'), (2,'전세/임대 전의 유의사항'), (2,'전세사기 위험');
+INSERT INTO subcategory_tb (category_id,name) VALUES (3,'요리'), (3,'세탁'), (3,'청소'), (3,'비용절감');
+INSERT INTO subcategory_tb (category_id,name) VALUES (4,'야구'), (4,'농구'), (4,'축구'), (4,'수영'), (4,'등산');
+INSERT INTO subcategory_tb (category_id,name) VALUES (5,'컴퓨터게임'), (5,'보드게임'), (5,'카드게임'), (5,'모바일게임');
+INSERT INTO subcategory_tb (category_id,name) VALUES (6,'클래식'), (6,'전자음악'), (6,'힙합'), (6,'재즈');


### PR DESCRIPTION
## 변경 요약
- 게시글 작성 api (POST "/content") 구현
- api 테스트 위해 임시로 "/content"와 "/h2-console/**"의 인증 제외 (SecurityConfig)
- 유저 인증이 없는 상태로 구현해 Post 테이블에 작성자, 작성일시는 제외함 (구현 예정)

- 요청 형식
  - "data" -> {"title": string, "subCategory": number, "description": string}
  - "file" -> 이미지 파일(MultipartFile) 리스트
  

<img width="648" alt="게시글작성-포스트맨" src="https://github.com/ieum-2024/ieum-backend/assets/83132869/238e39d4-b4dc-4753-9ddb-d77427b82966">

