### PR TITLE
게시글 상세조회 api 구현

### DIFF
--- a/src/main/java/cloud/ieum/Security/SecurityConfig.java
+++ b/src/main/java/cloud/ieum/Security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {  //해당 URL은 필터 거치지 않겠다
         log.info("무시하기");
-        return (web -> web.ignoring().requestMatchers("/img/**", "/css/**", "/js/**", "/content", "/h2-console/**"));
+        return (web -> web.ignoring().requestMatchers("/img/**", "/css/**", "/js/**", "/h2-console/**"));
         //return (web -> web.ignoring().antMatchers("/test"));
     }
     @Bean

--- a/src/main/java/cloud/ieum/content/image/Image.java
+++ b/src/main/java/cloud/ieum/content/image/Image.java
@@ -20,6 +20,6 @@ public class Image {
     @ManyToOne
     private Post post;
 
-    @Column(name = "image_url")
+    @Column
     private String imageUrl;
 }

--- a/src/main/java/cloud/ieum/content/image/Image.java
+++ b/src/main/java/cloud/ieum/content/image/Image.java
@@ -4,11 +4,13 @@ import cloud.ieum.content.post.Post;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Getter
 @Entity(name = "image_tb")
 public class Image {
     @Id

--- a/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
@@ -2,5 +2,8 @@ package cloud.ieum.content.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageJpaRepository extends JpaRepository<Image, Integer> {
+    List<Image> findImagesByPostId(Integer postId);
 }

--- a/src/main/java/cloud/ieum/content/image/ImageService.java
+++ b/src/main/java/cloud/ieum/content/image/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -33,5 +34,11 @@ public class ImageService {
             imageList.add(image);
         }
         imageJpaRepository.saveAll(imageList);
+    }
+
+    public List<String> getImgUrlsByPostId(Integer postId) {
+        return imageJpaRepository.findImagesByPostId(postId).stream()
+                .map(Image::getImageUrl)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/cloud/ieum/content/post/Post.java
+++ b/src/main/java/cloud/ieum/content/post/Post.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -25,4 +27,10 @@ public class Post {
 
     @Column(name = "content")
     private String content;
+
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    private Long createdBy;
 }

--- a/src/main/java/cloud/ieum/content/post/Post.java
+++ b/src/main/java/cloud/ieum/content/post/Post.java
@@ -22,10 +22,10 @@ public class Post {
     @ManyToOne(fetch = FetchType.LAZY)
     private SubCategory subCategory;
 
-    @Column(name = "title")
+    @Column
     private String title;
 
-    @Column(name = "content")
+    @Column
     private String content;
 
     @Column

--- a/src/main/java/cloud/ieum/content/post/PostDetailDto.java
+++ b/src/main/java/cloud/ieum/content/post/PostDetailDto.java
@@ -1,0 +1,18 @@
+package cloud.ieum.content.post;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PostDetailDto {
+    private Long menteeId;
+    private String title;
+    private LocalDateTime pubDate;
+    private String description;
+    private String nickname;
+    private List<String> images;
+}

--- a/src/main/java/cloud/ieum/content/post/PostRestController.java
+++ b/src/main/java/cloud/ieum/content/post/PostRestController.java
@@ -5,10 +5,7 @@ import cloud.ieum.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -25,5 +22,11 @@ public class PostRestController {
 
         postService.create(user.getUsername(), postRequestDto, images);
         return ResponseEntity.ok().body(ApiUtils.success(null));
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<?> getContentDetails(@AuthenticationPrincipal PrincipalDetail user, @RequestParam Integer content_id) throws Exception {
+        PostDetailDto responseDto = postService.getContentDetails(user.getUsername(), content_id);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
 }

--- a/src/main/java/cloud/ieum/content/post/PostRestController.java
+++ b/src/main/java/cloud/ieum/content/post/PostRestController.java
@@ -1,8 +1,10 @@
 package cloud.ieum.content.post;
 
+import cloud.ieum.user.PrincipalDetail;
 import cloud.ieum.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -18,9 +20,10 @@ public class PostRestController {
     private final PostService postService;
     @PostMapping("")
     public ResponseEntity<?> postContent(@RequestPart("data") PostRequestDto postRequestDto,
-                                         @RequestPart(value = "file", required = false) List<MultipartFile> images) throws Exception {
+                                         @RequestPart(value = "file", required = false) List<MultipartFile> images,
+                                         @AuthenticationPrincipal PrincipalDetail user) throws Exception {
 
-        postService.create(postRequestDto, images);
+        postService.create(user.getUsername(), postRequestDto, images);
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 }

--- a/src/main/java/cloud/ieum/content/post/PostService.java
+++ b/src/main/java/cloud/ieum/content/post/PostService.java
@@ -3,11 +3,13 @@ package cloud.ieum.content.post;
 import cloud.ieum.content.image.ImageService;
 import cloud.ieum.content.subcategory.SubCategory;
 import cloud.ieum.content.subcategory.SubCategoryService;
+import cloud.ieum.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,8 +19,10 @@ public class PostService {
     private final SubCategoryService subCategoryService;
     private final ImageService imageService;
     private final PostJpaRepository postJpaRepository;
+    private final UserRepository userRepository;
+
     @Transactional
-    public void create(PostRequestDto postRequestDto, List<MultipartFile> images) throws Exception {
+    public void create(String userName, PostRequestDto postRequestDto, List<MultipartFile> images) throws Exception {
         // subCategory 프록시 객체
         SubCategory subCategory = subCategoryService.getReferenceById(postRequestDto.getSubCategory());
 
@@ -27,11 +31,15 @@ public class PostService {
         if (images != null && !images.isEmpty()) {
             imgUrls = imageService.upload(images);
         }
+
+        Long userId = userRepository.findByName(userName).get().getId();
         
         Post post = Post.builder()
                 .title(postRequestDto.title)
                 .content(postRequestDto.description)
                 .subCategory(subCategory)
+                .createdAt(LocalDateTime.now())
+                .createdBy(userId)
                 .build();
         postJpaRepository.save(post);
 

--- a/src/main/java/cloud/ieum/content/post/PostService.java
+++ b/src/main/java/cloud/ieum/content/post/PostService.java
@@ -47,4 +47,17 @@ public class PostService {
             imageService.create(imgUrls, post);
         }
     }
+
+    public PostDetailDto getContentDetails(String userName, Integer postId) {
+        Post post = postJpaRepository.findById(postId).get();
+
+        return PostDetailDto.builder()
+                .menteeId(post.getCreatedBy())
+                .title(post.getTitle())
+                .pubDate(post.getCreatedAt())
+                .description(post.getContent())
+                .nickname(userName)
+                .images(imageService.getImgUrlsByPostId(postId))
+                .build();
+    }
 }

--- a/src/main/java/cloud/ieum/content/subcategory/SubCategory.java
+++ b/src/main/java/cloud/ieum/content/subcategory/SubCategory.java
@@ -12,6 +12,6 @@ public class SubCategory {
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
 
-    @Column(name = "name")
+    @Column
     private String name;
 }

--- a/src/main/java/cloud/ieum/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/cloud/ieum/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -35,6 +35,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String requestURI = request.getRequestURI();
+        if (requestURI.equals("/content")) return false;
         return Arrays.stream(whitelist).anyMatch(path::startsWith);
         //return PatternMatchUtils.simpleMatch(whitelist, requestURI);
     }

--- a/src/main/java/cloud/ieum/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/cloud/ieum/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -35,7 +35,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String requestURI = request.getRequestURI();
-        if (requestURI.equals("/content")) return false;
+
+        if (requestURI.startsWith("/content")) return false; // "/content" 필터 걸리도록 (임시 테스트용)
+
         return Arrays.stream(whitelist).anyMatch(path::startsWith);
         //return PatternMatchUtils.simpleMatch(whitelist, requestURI);
     }

--- a/src/main/java/cloud/ieum/user/repository/UserRepository.java
+++ b/src/main/java/cloud/ieum/user/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    //Optional<User> findByName(String name);
+    Optional<User> findByName(String name);
     //Optional<User> findByEmail(String email);
     //Optional<User> findByRefreshToken(String refreshToken);
     Optional<User> findBySocialId(String socialId);


### PR DESCRIPTION
## 변경사항
- 게시글 작성 api에 인증과 생성자, 생성시각 반영
- 게시글 상세조회 api 구현
- 게시글 관련 api "/content"로 시작하는 경로는 jwt filter에 걸리도록 임시로 제외함 (테스트용)

## 실행결과
- 게시글 상세조회 응답
<img width="659" alt="게시글 상세조회 응답" src="https://github.com/ieum-2024/ieum-backend/assets/83132869/1c95c1ff-6082-4a89-a9bd-3febfc6c461d">

