### PR TITLE
게시글 목록 조회 페이지네이션 구현

### DIFF
--- a/src/main/java/cloud/ieum/content/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cloud/ieum/content/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package cloud.ieum.content.exception;
+
+import cloud.ieum.utils.ApiUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.NoSuchElementException;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleAllExceptions(Exception ex, WebRequest request) {
+        log.error(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtils.error("An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(InvalidDataAccessResourceUsageException.class)
+    public ResponseEntity<?> handleDatabaseExceptions(InvalidDataAccessResourceUsageException ex, WebRequest request) {
+        log.error(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtils.error("Database error occurred", HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<?> handleNoSuchElementExceptions(NoSuchElementException ex, WebRequest request) {
+        log.error(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtils.error("No value present", HttpStatus.NOT_FOUND));
+    }
+
+}

--- a/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/image/ImageJpaRepository.java
@@ -1,9 +1,13 @@
 package cloud.ieum.content.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
+@Repository
 public interface ImageJpaRepository extends JpaRepository<Image, Integer> {
-    List<Image> findImagesByPostId(Integer postId);
+    List<Image> findByPostId(Integer postId);
+    Optional<Image> findFirstByPostId(Integer postId);
 }

--- a/src/main/java/cloud/ieum/content/image/ImageService.java
+++ b/src/main/java/cloud/ieum/content/image/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -37,8 +38,13 @@ public class ImageService {
     }
 
     public List<String> getImgUrlsByPostId(Integer postId) {
-        return imageJpaRepository.findImagesByPostId(postId).stream()
+        return imageJpaRepository.findByPostId(postId).stream()
                 .map(Image::getImageUrl)
                 .collect(Collectors.toList());
+    }
+
+    public String getFirstImagUrlByPostId(Integer postId) {
+        Optional<Image> image = imageJpaRepository.findFirstByPostId(postId);
+        return image.isEmpty() ? "" : image.get().getImageUrl();
     }
 }

--- a/src/main/java/cloud/ieum/content/post/Post.java
+++ b/src/main/java/cloud/ieum/content/post/Post.java
@@ -13,7 +13,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @Builder
-@Entity(name = "post_tb")
+@Entity
+@Table(name = "post_tb")
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/cloud/ieum/content/post/PostJpaRepository.java
+++ b/src/main/java/cloud/ieum/content/post/PostJpaRepository.java
@@ -1,7 +1,17 @@
 package cloud.ieum.content.post;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface PostJpaRepository extends JpaRepository<Post, Integer> {
-
+    @Query(value = "SELECT p FROM Post p " +
+            "WHERE p.id < :cursor AND p.subCategory.id = :interest " +
+            "ORDER by p.id DESC")
+    List<Post> findAllByInterestUsingCursor(@Param("interest") Integer interest, @Param("cursor")Integer cursor, Pageable pageable);
 }

--- a/src/main/java/cloud/ieum/content/post/PostRestController.java
+++ b/src/main/java/cloud/ieum/content/post/PostRestController.java
@@ -24,9 +24,15 @@ public class PostRestController {
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
-    @GetMapping("/detail")
-    public ResponseEntity<?> getContentDetails(@AuthenticationPrincipal PrincipalDetail user, @RequestParam Integer content_id) throws Exception {
-        PostDetailDto responseDto = postService.getContentDetails(user.getUsername(), content_id);
+    @GetMapping("/detail/{content_id}")
+    public ResponseEntity<?> getContentDetails(@PathVariable Integer content_id) {
+        PostDetailDto responseDto = postService.getPostDetails(content_id);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDto));
+    }
+
+    @GetMapping("/{interest_id}")
+    public ResponseEntity<?> getContentsByInterest(@PathVariable Integer interest_id, @RequestParam(required = false) Integer cursor) {
+        PostsByInterestDto responseDto = postService.getPostsByInterest(interest_id, cursor);
         return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
 }

--- a/src/main/java/cloud/ieum/content/post/PostService.java
+++ b/src/main/java/cloud/ieum/content/post/PostService.java
@@ -5,6 +5,7 @@ import cloud.ieum.content.subcategory.SubCategory;
 import cloud.ieum.content.subcategory.SubCategoryService;
 import cloud.ieum.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +21,9 @@ public class PostService {
     private final ImageService imageService;
     private final PostJpaRepository postJpaRepository;
     private final UserRepository userRepository;
+
+    private final int PAGE_SIZE = 5;
+    private final int PAGE_SIZE_PLUS_ONE = PAGE_SIZE + 1;
 
     @Transactional
     public void create(String userName, PostRequestDto postRequestDto, List<MultipartFile> images) throws Exception {
@@ -48,8 +52,9 @@ public class PostService {
         }
     }
 
-    public PostDetailDto getContentDetails(String userName, Integer postId) {
+    public PostDetailDto getPostDetails(Integer postId) {
         Post post = postJpaRepository.findById(postId).get();
+        String userName = userRepository.findById(post.getCreatedBy()).get().getName();
 
         return PostDetailDto.builder()
                 .menteeId(post.getCreatedBy())
@@ -60,4 +65,29 @@ public class PostService {
                 .images(imageService.getImgUrlsByPostId(postId))
                 .build();
     }
+
+    public PostsByInterestDto getPostsByInterest(Integer interestId, Integer cursor) {
+        Integer realCursor = cursor != null ? cursor : Integer.MAX_VALUE;
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_PLUS_ONE);
+        List<Post> postList = postJpaRepository.findAllByInterestUsingCursor(interestId, realCursor, pageable);
+
+        List<PostsByInterestDto.PostDto> postDtoList = new ArrayList<>();
+        for (Post post : postList) {
+            String userName = userRepository.findById(post.getCreatedBy()).get().getName();
+            String thumbnail = imageService.getFirstImagUrlByPostId(post.getId());
+            postDtoList.add(new PostsByInterestDto.PostDto(post.getId(), post.getTitle(), post.getCreatedAt(), post.getContent(), userName, thumbnail));
+        }
+        boolean hasNext = postDtoList.size() == PAGE_SIZE_PLUS_ONE ? true : false;
+        Integer nextCursor = 0;
+
+        if (hasNext) {
+            postDtoList.remove(PAGE_SIZE_PLUS_ONE - 1);
+            nextCursor = postList.get(PAGE_SIZE-1).getId();
+        }
+        PostsByInterestDto.CursorDto cursorDto = new PostsByInterestDto.CursorDto(nextCursor, hasNext);
+
+        return new PostsByInterestDto(postDtoList, cursorDto);
+    }
+
+
 }

--- a/src/main/java/cloud/ieum/content/post/PostsByInterestDto.java
+++ b/src/main/java/cloud/ieum/content/post/PostsByInterestDto.java
@@ -1,0 +1,32 @@
+package cloud.ieum.content.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PostsByInterestDto {
+    List<PostDto> contentList;
+    CursorDto cursor;
+
+    @Getter
+    @AllArgsConstructor
+    public static class PostDto {
+        Integer contentId;
+        String title;
+        LocalDateTime pubDate;
+        String description;
+        String nickname;
+        String thumbnail;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CursorDto {
+        Integer nextCursor;
+        boolean hasNext;
+    }
+}


### PR DESCRIPTION
## 변경사항
- 관심사 기반 게시글 목록 조회 api 구현
- 페이지 단위 5, 최신순으로 커서 기반 페이지네이션 구현
- 게시글 상세조회 형식을 API 문서와 일치하게 수정(content_id를 parameter->pathvariable로 변경)
- 게시글 상세조회 - 작성자 닉네임 버그 수정

## 실행결과
- 게시글 상세조회 api
<img width="658" alt="게시글상세조회응답(수정)" src="https://github.com/ieum-2024/ieum-backend/assets/83132869/614fbc8d-89ec-409c-85a3-546d952687a9">

- 게시글 목록조회 api
<img width="658" alt="게시글목록조회응답" src="https://github.com/ieum-2024/ieum-backend/assets/83132869/7c90513e-80ca-4970-9c89-c453b65a57f6">
<img width="659" alt="게시글목록조회응답2" src="https://github.com/ieum-2024/ieum-backend/assets/83132869/3ad81907-9093-4123-b5f8-1b889806f85e">
